### PR TITLE
Introduce end-of-line normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+*.sh text eol=lf
+*.conf text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 # Ignore Ansible retry files
 *.retry
+
+# Ignore IDEs
+.vscode

--- a/nginx-regex-tester/regextester/start.sh
+++ b/nginx-regex-tester/regextester/start.sh
@@ -2,7 +2,7 @@
 
 nginx
 
-i=`curl -s -o /dev/null -w "%{http_code}" 0.0.0.0`
+i=$(curl -s -o /dev/null -w "%{http_code}" 0.0.0.0)
 if [ "$i" != "200" ]; then
     echo "NGINX failed to start: Status $1"
     exit 1
@@ -12,7 +12,7 @@ echo "NGINX started"
 
 unitd --modules /usr/lib/unit/modules/ --log /var/log/unit.log
 
-i=`curl --unix-socket /run/control.unit.sock -s -o /dev/null -w "%{http_code}" localhost/config`
+i=$(curl --unix-socket /run/control.unit.sock -s -o /dev/null -w "%{http_code}" localhost/config)
 if [ "$i" != "200" ]; then
     echo "Unit failed to start: Status $1"
     exit 1
@@ -20,7 +20,7 @@ fi
 
 echo "Unit started"
 
-i=`curl --unix-socket /run/control.unit.sock -s -o /dev/null -w "%{http_code}" -X PUT -d @/srv/unitphp.config http://localhost/config/`
+i=$(curl --unix-socket /run/control.unit.sock -s -o /dev/null -w "%{http_code}" -X PUT -d @/srv/unitphp.config http://localhost/config/)
 
 if [ "$i" != "200" ]; then
     echo "Unit configuration failed: Status $1"
@@ -29,14 +29,13 @@ fi
 
 echo "Unit configured"
 
-while [ "$i" = "200" ];
-do
-    sleep 30;
-    i=`curl -s -o /dev/null -w "%{http_code}" 0.0.0.0`
+while [ "$i" = "200" ]; do
+    sleep 30
+    i=$(curl -s -o /dev/null -w "%{http_code}" 0.0.0.0)
     if [ "$i" != "200" ]; then
         echo "NGINX is not running: Status $1"
     else
-        i=`curl --unix-socket /run/control.unit.sock -s -o /dev/null -w "%{http_code}" localhost`
+        i=$(curl --unix-socket /run/control.unit.sock -s -o /dev/null -w "%{http_code}" localhost)
         if [ "$i" != "200" ]; then
             echo "Unit is not running: Status $1"
         fi


### PR DESCRIPTION
Tentatively fixes #37. Forces git to use `LF` for `.sh` and `.conf` files, no matter the OS where they are used/edited.