### PR TITLE
Update deprecated command in workflow

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -32,7 +32,7 @@ jobs:
         id: variables
         run: |
           image=$(cut -d"," -f1 <<< "${{ matrix.tag }}")
-          echo "::set-output name=image::${image}"
+          echo "image=${image}" >> $GITHUB_OUTPUT
       - name: Check if update needed for ${{ steps.variables.outputs.image }}
         id: update
         uses: lucacome/docker-image-update-checker@v1


### PR DESCRIPTION
Fixes the warning:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
